### PR TITLE
feat: hideEmptyGroups respects groupOrder for empty columns

### DIFF
--- a/src/Views/BoardDataBuilder.ts
+++ b/src/Views/BoardDataBuilder.ts
@@ -78,24 +78,42 @@ export class BoardViewDataBuilder {
             }
         }
 
-        // From vault (if not hiding empty)
+        // From groupOrder or vault (if not hiding empty)
         if (!options.hideEmptyGroups && groupPropertyId) {
-            const propertyManager = new PropertyManager();
-            const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(groupPropertyId));
-            for (const val of allValues) {
-                if (!groupValues.has(val)) {
-                    groupValues.set(val, val);
+            const groupOrder = options.groupOrder || [];
+            if (groupOrder.length > 0) {
+                for (const val of groupOrder) {
+                    if (!groupValues.has(val)) {
+                        groupValues.set(val, val);
+                    }
+                }
+            } else {
+                const propertyManager = new PropertyManager();
+                const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(groupPropertyId));
+                for (const val of allValues) {
+                    if (!groupValues.has(val)) {
+                        groupValues.set(val, val);
+                    }
                 }
             }
             if (!groupValues.has(EMPTY_GROUP_VALUE)) groupValues.set(EMPTY_GROUP_VALUE, null);
         }
 
         if (!options.hideEmptySubGroups && subGroupPropertyId) {
-            const propertyManager = new PropertyManager();
-            const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(subGroupPropertyId));
-            for (const val of allValues) {
-                if (!subGroupValues.has(val)) {
-                    subGroupValues.set(val, val);
+            const subGroupOrder = options.subGroupOrder || [];
+            if (subGroupOrder.length > 0) {
+                for (const val of subGroupOrder) {
+                    if (!subGroupValues.has(val)) {
+                        subGroupValues.set(val, val);
+                    }
+                }
+            } else {
+                const propertyManager = new PropertyManager();
+                const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(subGroupPropertyId));
+                for (const val of allValues) {
+                    if (!subGroupValues.has(val)) {
+                        subGroupValues.set(val, val);
+                    }
                 }
             }
             if (!subGroupValues.has(EMPTY_GROUP_VALUE)) subGroupValues.set(EMPTY_GROUP_VALUE, null);

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,7 @@ export default class BoardViewPlugin extends Plugin {
 							displayName: 'Hide empty groups',
 							key: BoardOptionKeys.HIDE_EMPTY_GROUPS,
 							default: false,
-							description: 'Hide empty groups (columns)',
+							description: 'Hide groups with no cards. When off, groups from Group order are always shown',
 						},
 						{
 							type: 'multitext',


### PR DESCRIPTION
When `hideEmptyGroups` is off:
- If `groupOrder` is set → show those columns even if empty
- If `groupOrder` is empty → show all values from vault (original behavior)