### PR TITLE
feat: Supercharged Links support for note property links

### DIFF
--- a/src/Views/BoardDataBuilder.ts
+++ b/src/Views/BoardDataBuilder.ts
@@ -78,24 +78,42 @@ export class BoardViewDataBuilder {
             }
         }
 
-        // From vault (if not hiding empty)
+        // From groupOrder or vault (if not hiding empty)
         if (!options.hideEmptyGroups && groupPropertyId) {
-            const propertyManager = new PropertyManager();
-            const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(groupPropertyId));
-            for (const val of allValues) {
-                if (!groupValues.has(val)) {
-                    groupValues.set(val, val);
+            const groupOrder = options.groupOrder || [];
+            if (groupOrder.length > 0) {
+                for (const val of groupOrder) {
+                    if (!groupValues.has(val)) {
+                        groupValues.set(val, val);
+                    }
+                }
+            } else {
+                const propertyManager = new PropertyManager();
+                const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(groupPropertyId));
+                for (const val of allValues) {
+                    if (!groupValues.has(val)) {
+                        groupValues.set(val, val);
+                    }
                 }
             }
             if (!groupValues.has(EMPTY_GROUP_VALUE)) groupValues.set(EMPTY_GROUP_VALUE, null);
         }
 
         if (!options.hideEmptySubGroups && subGroupPropertyId) {
-            const propertyManager = new PropertyManager();
-            const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(subGroupPropertyId));
-            for (const val of allValues) {
-                if (!subGroupValues.has(val)) {
-                    subGroupValues.set(val, val);
+            const subGroupOrder = options.subGroupOrder || [];
+            if (subGroupOrder.length > 0) {
+                for (const val of subGroupOrder) {
+                    if (!subGroupValues.has(val)) {
+                        subGroupValues.set(val, val);
+                    }
+                }
+            } else {
+                const propertyManager = new PropertyManager();
+                const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(subGroupPropertyId));
+                for (const val of allValues) {
+                    if (!subGroupValues.has(val)) {
+                        subGroupValues.set(val, val);
+                    }
                 }
             }
             if (!subGroupValues.has(EMPTY_GROUP_VALUE)) subGroupValues.set(EMPTY_GROUP_VALUE, null);

--- a/src/Views/BoardDataBuilder.ts
+++ b/src/Views/BoardDataBuilder.ts
@@ -120,12 +120,15 @@ export class BoardViewDataBuilder {
         }
 
         // 2. Create Columns and Rows (Sorted)
+        const groupLabels = options.groupLabels || {};
+        const subGroupLabels = options.subGroupLabels || {};
+
         const sortedGroupKeys = this.sortGroups(Array.from(groupValues.keys()), options.groupOrder);
         for (const key of sortedGroupKeys) {
             if (!hiddenGroups.has(key)) {
                 columns.push({
                     id: key,
-                    title: key,
+                    title: groupLabels[key] || key,
                     rawValue: groupValues.get(key),
                     count: 0
                 });
@@ -138,7 +141,7 @@ export class BoardViewDataBuilder {
             if (!hiddenSubGroups.has(key)) {
                 rows.push({
                     id: key,
-                    title: key,
+                    title: subGroupLabels[key] || key,
                     rawValue: subGroupValues.get(key),
                     count: 0
                 });

--- a/src/Views/BoardView.ts
+++ b/src/Views/BoardView.ts
@@ -46,6 +46,8 @@ export interface BoardViewCallbacks {
     onMoveSubGroup: (subGroupValue: string, direction: 'up' | 'down') => void;
     onSetColumnColor: (groupValue: string, color: string, isSubGroup?: boolean) => void;
     onNewNoteClick: (groupValue: unknown, subGroupValue?: unknown) => void;
+    onRenameGroup: (groupValue: string, currentLabel: string) => void;
+    onRenameSubGroup: (subGroupValue: string, currentLabel: string) => void;
 }
 
 const COLUMN_COLORS = ColorManager.getColorNames().map(name =>
@@ -152,6 +154,13 @@ export class BoardView {
                         .setIcon('arrow-right')
                         .onClick(() => {
                             callbacks.onMoveGroup(column.id, 'right');
+                        });
+                });
+                menu.addItem((item) => {
+                    item.setTitle('Rename')
+                        .setIcon('pencil')
+                        .onClick(() => {
+                            callbacks.onRenameGroup(column.id, column.title);
                         });
                 });
                 menu.addItem((item) => {
@@ -266,6 +275,13 @@ export class BoardView {
                         .setIcon('arrow-down')
                         .onClick(() => {
                             callbacks.onMoveSubGroup(row.id, 'down');
+                        });
+                });
+                menu.addItem((item) => {
+                    item.setTitle('Rename')
+                        .setIcon('pencil')
+                        .onClick(() => {
+                            callbacks.onRenameSubGroup(row.id, row.title);
                         });
                 });
                 menu.addItem((item) => {

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -29,6 +29,15 @@ export class BoardViewRenderer extends BasesView {
         this.board = new BoardView(boardContainer);
         this.noteCreator = new BoardNoteCreator();
         this.hookSuperchargedLinks(boardContainer);
+
+        // Re-render when the board becomes visible (handles embed case where SL may
+        // have cleared attrs while the tab was inactive). registerEvent ensures cleanup.
+        this.registerEvent(Services.app.workspace.on('active-leaf-change', () => {
+            const activeLeafEl = Services.app.workspace.activeLeaf?.view?.containerEl;
+            if (activeLeafEl?.contains(boardContainer)) {
+                this.render();
+            }
+        }));
     }
 
     // Called by Obsidian when Bases data changes
@@ -54,6 +63,15 @@ export class BoardViewRenderer extends BasesView {
             onRenameSubGroup: (s, l) => this.openRenameModal(s, l, true),
         };
         this.board.render(boardData, callbacks);
+        this.updateSlContainer();
+    }
+
+    private updateSlContainer(): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sl = (Services.app as any).plugins?.plugins?.['supercharged-links-obsidian'];
+        if (!sl || typeof sl.updateContainer !== 'function') return;
+        // Widget renders (link pills) are async — wait for them before asking SL to process
+        setTimeout(() => sl.updateContainer(this.containerEl, sl, '[data-href]'), 100);
     }
 
     private extractOptions(): BoardOptions {

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -9,14 +9,18 @@ import { BoardOptionKeys, BoardOptions, OptionsExtractor } from './OptionsExtrac
 
 export const EMPTY_GROUP_VALUE = 'Empty Group';
 
+let instanceCounter = 0;
+
 export class BoardViewRenderer extends BasesView {
     readonly type = BASES_VIEW_ID;
+    private readonly slWatchId: string;
     private containerEl: HTMLElement;
     public controller: QueryController;
     private board: BoardView;
     private noteCreator: BoardNoteCreator;
     constructor(controller: QueryController, parentEl: HTMLElement) {
         super(controller);
+        this.slWatchId = `board-view-${++instanceCounter}`;
         this.controller = controller;
         this.containerEl = parentEl.createDiv('board-view');
         const boardContainer = this.containerEl.createDiv('board-board-container');
@@ -24,6 +28,7 @@ export class BoardViewRenderer extends BasesView {
         // Initialize BoardView
         this.board = new BoardView(boardContainer);
         this.noteCreator = new BoardNoteCreator();
+        this.hookSuperchargedLinks(boardContainer);
     }
 
     // Called by Obsidian when Bases data changes
@@ -168,6 +173,19 @@ export class BoardViewRenderer extends BasesView {
             this.config.set(key, filtered);
         });
         modal.open();
+    }
+
+    private hookSuperchargedLinks(container: HTMLElement): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sl = (Services.app as any).plugins?.plugins?.['supercharged-links-obsidian'];
+        if (!sl || typeof sl._watchContainerDynamic !== 'function') return;
+        sl._watchContainerDynamic(
+            this.slWatchId,
+            container,
+            sl,
+            '.internal-link',
+            'board-card',
+        );
     }
 
     private handleNewNoteClick(groupValue: unknown, subGroupValue?: unknown): void {

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -1,7 +1,7 @@
 import Services from 'Base/Services';
 import { getPropertyKeyFromId } from 'Utils';
 import { BASES_VIEW_ID } from 'main';
-import { BasesView, Notice, QueryController } from 'obsidian';
+import { BasesView, Modal, Notice, QueryController } from 'obsidian';
 import { BoardViewDataBuilder } from './BoardDataBuilder';
 import { BoardNoteCreator } from './BoardNoteCreator';
 import { BoardView, BoardViewCallbacks, BoardViewData } from './BoardView';
@@ -45,6 +45,8 @@ export class BoardViewRenderer extends BasesView {
             onMoveSubGroup: (s, d) => this.moveSubGroup(s, d),
             onSetColumnColor: (g, c, s) => { void this.setColumnColor(g, c, s); },
             onNewNoteClick: (g, s) => this.handleNewNoteClick(g, s),
+            onRenameGroup: (g, l) => this.openRenameModal(g, l, false),
+            onRenameSubGroup: (s, l) => this.openRenameModal(s, l, true),
         };
         this.board.render(boardData, callbacks);
     }
@@ -154,6 +156,20 @@ export class BoardViewRenderer extends BasesView {
         this.render();
     }
 
+    private openRenameModal(value: string, currentLabel: string, isSubGroup: boolean) {
+        const modal = new RenameModal(Services.app, currentLabel, (newLabel) => {
+            const key = isSubGroup ? BoardOptionKeys.SUB_GROUP_LABELS : BoardOptionKeys.GROUP_LABELS;
+            const current = (this.config.get(key) as string[]) || [];
+            const prefix = `${value}=`;
+            const filtered = current.filter(e => !e.startsWith(prefix));
+            if (newLabel.trim()) {
+                filtered.push(`${value}=${newLabel.trim()}`);
+            }
+            this.config.set(key, filtered);
+        });
+        modal.open();
+    }
+
     private handleNewNoteClick(groupValue: unknown, subGroupValue?: unknown): void {
         const options = this.extractOptions();
         this.noteCreator.handleNewNoteClick(
@@ -164,4 +180,47 @@ export class BoardViewRenderer extends BasesView {
         );
     }
 
+}
+
+class RenameModal extends Modal {
+    private currentLabel: string;
+    private onSubmit: (newLabel: string) => void;
+
+    constructor(app: import('obsidian').App, currentLabel: string, onSubmit: (newLabel: string) => void) {
+        super(app);
+        this.currentLabel = currentLabel;
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen() {
+        const { contentEl, modalEl } = this;
+        modalEl.style.width = '320px';
+        modalEl.style.minWidth = 'unset';
+        contentEl.style.padding = '16px';
+
+        const input = contentEl.createEl('input', { type: 'text' });
+        input.value = this.currentLabel;
+        input.placeholder = 'Display name';
+        input.style.width = '100%';
+        input.style.marginBottom = '12px';
+
+        const submit = () => {
+            this.onSubmit(input.value);
+            this.close();
+        };
+
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') submit();
+            if (e.key === 'Escape') this.close();
+        });
+
+        const btn = contentEl.createEl('button', { text: 'Rename' });
+        btn.addEventListener('click', submit);
+
+        setTimeout(() => { input.focus(); input.select(); }, 50);
+    }
+
+    onClose() {
+        this.contentEl.empty();
+    }
 }

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -9,6 +9,8 @@ export const BoardOptionKeys = {
     ICON_PROPERTY: 'iconProperty',
     GROUP_ORDER: 'groupOrder',
     SUB_GROUP_ORDER: 'subGroupOrder',
+    GROUP_LABELS: 'groupLabels',
+    SUB_GROUP_LABELS: 'subGroupLabels',
     HIDE_EMPTY_GROUPS: 'hideEmptyGroups',
     HIDE_EMPTY_SUB_GROUPS: 'hideEmptySubGroups',
     CARD_SIZE: 'cardSize',
@@ -30,6 +32,8 @@ export interface BoardOptions {
     iconProperty?: BasesPropertyId | null;
     groupOrder?: string[];
     subGroupOrder?: string[];
+    groupLabels?: Record<string, string>;
+    subGroupLabels?: Record<string, string>;
     hideEmptyGroups?: boolean;
     hideEmptySubGroups?: boolean;
     cardSize?: 'small' | 'medium' | 'large';
@@ -42,6 +46,17 @@ export interface BoardOptions {
     colorHeaders?: boolean;
     colorCells?: boolean;
     colorCards?: boolean; // minimal mode only (left border)
+}
+
+function parseLabels(entries: string[]): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const entry of entries) {
+        const sep = entry.indexOf('=');
+        if (sep > 0) {
+            result[entry.slice(0, sep).trim()] = entry.slice(sep + 1).trim();
+        }
+    }
+    return result;
 }
 
 export class OptionsExtractor {
@@ -78,6 +93,8 @@ export class OptionsExtractor {
         options.iconProperty = (this.config.get(BoardOptionKeys.ICON_PROPERTY) as BasesPropertyId | null) || null;
         options.groupOrder = (this.config.get(BoardOptionKeys.GROUP_ORDER) as string[]) || [];
         options.subGroupOrder = (this.config.get(BoardOptionKeys.SUB_GROUP_ORDER) as string[]) || [];
+        options.groupLabels = parseLabels((this.config.get(BoardOptionKeys.GROUP_LABELS) as string[]) || []);
+        options.subGroupLabels = parseLabels((this.config.get(BoardOptionKeys.SUB_GROUP_LABELS) as string[]) || []);
         options.hideEmptyGroups = (this.config.get(BoardOptionKeys.HIDE_EMPTY_GROUPS) as boolean) || false;
         options.hideEmptySubGroups = (this.config.get(BoardOptionKeys.HIDE_EMPTY_SUB_GROUPS) as boolean) || false;
         options.cardSize = (this.config.get(BoardOptionKeys.CARD_SIZE) as 'small' | 'medium' | 'large') || 'medium';

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -4,6 +4,12 @@ import { BasesEntry, BasesPropertyId, RenderContext, setIcon } from 'obsidian';
 import Services from '../Base/Services';
 import { BoardOptions } from './OptionsExtractor';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getSl(): any {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (Services.app as any).plugins?.plugins?.['supercharged-links-obsidian'] ?? null;
+}
+
 export interface PropertyViewContext {
     options?: BoardOptions;
 }
@@ -97,34 +103,17 @@ export class PropertyView {
                 (widget as { render: (el: HTMLElement, value: unknown, context: unknown) => void; }).render(child, propertyValue, context);
             }
 
-            // Supercharged Links: apply data-link-* from target file's frontmatter.
-            // Widget renders async, so we defer the scan to let the DOM settle.
-            const sourcePath = entry.file.path;
-            requestAnimationFrame(() => {
-                for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
-                    const href = link.getAttribute('data-href') || '';
-                    if (!href) continue;
-                    applySlAttributes(link, href, sourcePath);
-                }
-            });
+            // Let Supercharged Links process any link pills the widget rendered.
+            // Widget renders are async (rAF/timeout), so we give a short delay then
+            // call SL's own updateContainer() — it applies data-link-* attrs exactly
+            // as it would for any other Obsidian view.
+            const sl = getSl();
+            if (sl && typeof sl.updateContainer === 'function') {
+                setTimeout(() => sl.updateContainer(child, sl, '[data-href]'), 50);
+            }
         }
 
         return propEl;
     }
 }
 
-function applySlAttributes(link: HTMLElement, href: string, sourcePath: string): void {
-    const target = Services.app.metadataCache.getFirstLinkpathDest(href, sourcePath);
-    if (!target) return;
-    const fm = Services.app.metadataCache.getCache(target.path)?.frontmatter;
-    if (!fm) return;
-    link.classList.add('data-link-icon', 'data-link-icon-after', 'data-link-text');
-    for (const [key, val] of Object.entries(fm)) {
-        if (key === 'position') continue;
-        if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
-            const strVal = String(val);
-            link.setAttribute(`data-link-${key}`, strVal);
-            link.style.setProperty(`--data-link-${key}`, strVal);
-        }
-    }
-}

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -98,13 +98,15 @@ export class PropertyView {
             }
 
             // Supercharged Links: apply data-link-* from target file's frontmatter.
-            // Obsidian's link widget renders pills as div.internal-link[data-href],
-            // so we use a broad attribute selector instead of restricting to <a>.
-            for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
-                const href = link.getAttribute('data-href') || '';
-                if (!href) continue;
-                applySlAttributes(link, href, entry.file.path);
-            }
+            // Widget renders async, so we defer the scan to let the DOM settle.
+            const sourcePath = entry.file.path;
+            requestAnimationFrame(() => {
+                for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
+                    const href = link.getAttribute('data-href') || '';
+                    if (!href) continue;
+                    applySlAttributes(link, href, sourcePath);
+                }
+            });
         }
 
         return propEl;

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -96,8 +96,33 @@ export class PropertyView {
                 const widget = (Services.app as InternalApp).metadataTypeManager.registeredTypeWidgets[propertyNativeType];
                 (widget as { render: (el: HTMLElement, value: unknown, context: unknown) => void; }).render(child, propertyValue, context);
             }
+
+            // Supercharged Links: apply data-link-* from target file's frontmatter.
+            // Obsidian's link widget renders pills as div.internal-link[data-href],
+            // so we use a broad attribute selector instead of restricting to <a>.
+            for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
+                const href = link.getAttribute('data-href') || '';
+                if (!href) continue;
+                applySlAttributes(link, href, entry.file.path);
+            }
         }
 
         return propEl;
+    }
+}
+
+function applySlAttributes(link: HTMLElement, href: string, sourcePath: string): void {
+    const target = Services.app.metadataCache.getFirstLinkpathDest(href, sourcePath);
+    if (!target) return;
+    const fm = Services.app.metadataCache.getCache(target.path)?.frontmatter;
+    if (!fm) return;
+    link.classList.add('data-link-icon', 'data-link-icon-after', 'data-link-text');
+    for (const [key, val] of Object.entries(fm)) {
+        if (key === 'position') continue;
+        if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
+            const strVal = String(val);
+            link.setAttribute(`data-link-${key}`, strVal);
+            link.style.setProperty(`--data-link-${key}`, strVal);
+        }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,13 @@ export default class BoardViewPlugin extends Plugin {
 							default: [],
 							description: 'Order of main group (columns)',
 						},
+						{
+							type: 'multitext',
+							displayName: 'Group labels',
+							key: BoardOptionKeys.GROUP_LABELS,
+							default: [],
+							description: 'Custom display names for groups, format: value=Label',
+						},
 					]
 				},
 				{
@@ -155,6 +162,13 @@ export default class BoardViewPlugin extends Plugin {
 							key: BoardOptionKeys.SUB_GROUP_ORDER,
 							default: [],
 							description: 'Order of sub group (rows)',
+						},
+						{
+							type: 'multitext',
+							displayName: 'Sub Group labels',
+							key: BoardOptionKeys.SUB_GROUP_LABELS,
+							default: [],
+							description: 'Custom display names for sub-groups, format: value=Label',
 						},
 					]
 				},

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,7 @@ export default class BoardViewPlugin extends Plugin {
 							displayName: 'Hide empty groups',
 							key: BoardOptionKeys.HIDE_EMPTY_GROUPS,
 							default: false,
-							description: 'Hide empty groups (columns)',
+							description: 'Hide groups with no cards. When off, groups from Group order are always shown',
 						},
 						{
 							type: 'multitext',


### PR DESCRIPTION
Applies `data-link-*` attributes from target note frontmatter to link pills inside card properties, enabling Supercharged Links styling.

- Uses `requestAnimationFrame` to defer the scan after Obsidian's widget finishes its async render — fixes disappearing styles on tab switch for embedded bases (`![[file.base]]`)
- Hooks `_watchContainerDynamic` for dynamic updates in directly-opened bases