### PR TITLE
feat: ID property — muted badge above card title

### DIFF
--- a/src/Views/CardView.ts
+++ b/src/Views/CardView.ts
@@ -1,6 +1,7 @@
-import { BasesEntry, Menu, WorkspaceLeaf } from 'obsidian';
+import { BasesEntry, Menu, Modal, Notice, WorkspaceLeaf } from 'obsidian';
 import { InternalWorkspace } from 'Types/Internal';
 import Services from '../Base/Services';
+import { getPropertyKeyFromId } from 'Utils';
 import { ColorManager } from './ColorManager';
 import { BoardOptions } from './OptionsExtractor';
 import { PropertyView } from './PropertyView';
@@ -113,6 +114,40 @@ export class CardView {
             }
         }
 
+        // ID badge above title
+        if (this.options.idProperty) {
+            const idPropertyId = this.options.idProperty;
+            const idValue = entry.getValue(idPropertyId);
+            if (idValue?.isTruthy()) {
+                const idText = idValue.toString();
+                const idEl = document.createElement('div');
+                idEl.classList.add('card-id');
+                idEl.textContent = idText;
+
+                idEl.addEventListener('mouseup', (evt) => { evt.stopPropagation(); });
+
+                idEl.addEventListener('click', (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    navigator.clipboard.writeText(idText);
+                    new Notice(`Copied: ${idText}`, 1500);
+                });
+
+                idEl.addEventListener('contextmenu', (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    const modal = new IdEditModal(Services.app, idText, async (newValue) => {
+                        const key = getPropertyKeyFromId(idPropertyId);
+                        const file = Services.propertyManager.getFile(entry.file.path);
+                        if (file) await Services.propertyManager.updateFrontmatter(file, key, newValue);
+                    });
+                    modal.open();
+                });
+
+                card.appendChild(idEl);
+            }
+        }
+
         // create PropertyView helper
         const propertyView = new PropertyView({
             options: this.options
@@ -127,4 +162,31 @@ export class CardView {
 
         return card;
     }
+}
+
+class IdEditModal extends Modal {
+    constructor(
+        app: import('obsidian').App,
+        private currentValue: string,
+        private onSubmit: (newValue: string) => Promise<void>
+    ) { super(app); }
+
+    onOpen() {
+        const { contentEl, modalEl } = this;
+        modalEl.style.width = '280px';
+        modalEl.style.minWidth = 'unset';
+        contentEl.style.padding = '16px';
+
+        const input = contentEl.createEl('input', { type: 'text' });
+        input.value = this.currentValue;
+        input.style.width = '100%';
+        input.style.marginBottom = '12px';
+
+        const submit = () => { void this.onSubmit(input.value.trim()).then(() => this.close()); };
+        input.addEventListener('keydown', (e) => { if (e.key === 'Enter') submit(); if (e.key === 'Escape') this.close(); });
+        contentEl.createEl('button', { text: 'Save' }).addEventListener('click', submit);
+        setTimeout(() => { input.focus(); input.select(); }, 50);
+    }
+
+    onClose() { this.contentEl.empty(); }
 }

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -7,6 +7,7 @@ export const BoardOptionKeys = {
     SUB_GROUP_PROPERTY: 'subGroupProperty',
     IMAGE_PROPERTY: 'imageProperty',
     ICON_PROPERTY: 'iconProperty',
+    ID_PROPERTY: 'idProperty',
     GROUP_ORDER: 'groupOrder',
     SUB_GROUP_ORDER: 'subGroupOrder',
     HIDE_EMPTY_GROUPS: 'hideEmptyGroups',
@@ -28,6 +29,7 @@ export interface BoardOptions {
     subGroupProperty?: BasesPropertyId | null;
     imageProperty?: BasesPropertyId | null;
     iconProperty?: BasesPropertyId | null;
+    idProperty?: BasesPropertyId | null;
     groupOrder?: string[];
     subGroupOrder?: string[];
     hideEmptyGroups?: boolean;
@@ -76,6 +78,7 @@ export class OptionsExtractor {
         options.subGroupProperty = subGroupProperty;
         options.imageProperty = (this.config.get(BoardOptionKeys.IMAGE_PROPERTY) as BasesPropertyId | null) || null;
         options.iconProperty = (this.config.get(BoardOptionKeys.ICON_PROPERTY) as BasesPropertyId | null) || null;
+        options.idProperty = (this.config.get(BoardOptionKeys.ID_PROPERTY) as BasesPropertyId | null) || null;
         options.groupOrder = (this.config.get(BoardOptionKeys.GROUP_ORDER) as string[]) || [];
         options.subGroupOrder = (this.config.get(BoardOptionKeys.SUB_GROUP_ORDER) as string[]) || [];
         options.hideEmptyGroups = (this.config.get(BoardOptionKeys.HIDE_EMPTY_GROUPS) as boolean) || false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,14 @@ export default class BoardViewPlugin extends Plugin {
 							description: 'Enter the property ID to display as card icon',
 						},
 						{
+							type: 'property',
+							displayName: 'ID Property',
+							key: BoardOptionKeys.ID_PROPERTY,
+							filter: (prop: string) => Services.plugin.isPropertyEligibleForGrouping(prop),
+							default: '',
+							description: 'Property shown as a muted ID above the card title. Click to copy, right-click to edit.',
+						},
+						{
 							type: 'toggle',
 							displayName: 'Open in side view',
 							key: BoardOptionKeys.OPEN_IN_SIDE_VIEW,

--- a/styles.css
+++ b/styles.css
@@ -454,3 +454,11 @@ body {
     text-decoration: none;
     padding-left: 6px;
 }
+
+.card-id {
+    padding-left: 6px;
+    font-size: var(--font-ui-smaller);
+    opacity: 0.45;
+    cursor: pointer;
+    user-select: none;
+}


### PR DESCRIPTION
Adds an optional **ID Property** setting (under Appearance).

When set, the property value is shown above the card title in a muted style — left-click copies it to clipboard, right-click opens an edit dialog.