### PR TITLE
feat: icon mapping and icon picker

### DIFF
--- a/src/Types/Internal.ts
+++ b/src/Types/Internal.ts
@@ -1,4 +1,4 @@
-import { App, Menu, MenuItem, MetadataCache, TFile, Value, Workspace, WorkspaceLeaf } from "obsidian";
+import { App, FileManager, Menu, MenuItem, MetadataCache, TFile, TFolder, Value, Workspace, WorkspaceLeaf } from "obsidian";
 
 export interface MetadataTypeManager {
     registeredTypeWidgets: Record<string, unknown>;
@@ -22,6 +22,10 @@ export interface InternalMenuItem extends MenuItem {
 
 export interface InternalMetadataCache extends MetadataCache {
     getFrontmatterPropertyValuesForKey(key: string): string[];
+}
+
+export interface InternalFileManager extends FileManager {
+    createNewMarkdownFile(folder: TFolder, filename: string): Promise<TFile>;
 }
 
 export interface PropertyData extends Value {

--- a/src/Views/BoardDataBuilder.ts
+++ b/src/Views/BoardDataBuilder.ts
@@ -78,24 +78,42 @@ export class BoardViewDataBuilder {
             }
         }
 
-        // From vault (if not hiding empty)
+        // From groupOrder or vault (if not hiding empty)
         if (!options.hideEmptyGroups && groupPropertyId) {
-            const propertyManager = new PropertyManager();
-            const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(groupPropertyId));
-            for (const val of allValues) {
-                if (!groupValues.has(val)) {
-                    groupValues.set(val, val);
+            const groupOrder = options.groupOrder || [];
+            if (groupOrder.length > 0) {
+                for (const val of groupOrder) {
+                    if (!groupValues.has(val)) {
+                        groupValues.set(val, val);
+                    }
+                }
+            } else {
+                const propertyManager = new PropertyManager();
+                const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(groupPropertyId));
+                for (const val of allValues) {
+                    if (!groupValues.has(val)) {
+                        groupValues.set(val, val);
+                    }
                 }
             }
             if (!groupValues.has(EMPTY_GROUP_VALUE)) groupValues.set(EMPTY_GROUP_VALUE, null);
         }
 
         if (!options.hideEmptySubGroups && subGroupPropertyId) {
-            const propertyManager = new PropertyManager();
-            const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(subGroupPropertyId));
-            for (const val of allValues) {
-                if (!subGroupValues.has(val)) {
-                    subGroupValues.set(val, val);
+            const subGroupOrder = options.subGroupOrder || [];
+            if (subGroupOrder.length > 0) {
+                for (const val of subGroupOrder) {
+                    if (!subGroupValues.has(val)) {
+                        subGroupValues.set(val, val);
+                    }
+                }
+            } else {
+                const propertyManager = new PropertyManager();
+                const allValues = propertyManager.getPropertyValues(getPropertyKeyFromId(subGroupPropertyId));
+                for (const val of allValues) {
+                    if (!subGroupValues.has(val)) {
+                        subGroupValues.set(val, val);
+                    }
                 }
             }
             if (!subGroupValues.has(EMPTY_GROUP_VALUE)) subGroupValues.set(EMPTY_GROUP_VALUE, null);

--- a/src/Views/BoardDataBuilder.ts
+++ b/src/Views/BoardDataBuilder.ts
@@ -120,12 +120,15 @@ export class BoardViewDataBuilder {
         }
 
         // 2. Create Columns and Rows (Sorted)
+        const groupLabels = options.groupLabels || {};
+        const subGroupLabels = options.subGroupLabels || {};
+
         const sortedGroupKeys = this.sortGroups(Array.from(groupValues.keys()), options.groupOrder);
         for (const key of sortedGroupKeys) {
             if (!hiddenGroups.has(key)) {
                 columns.push({
                     id: key,
-                    title: key,
+                    title: groupLabels[key] || key,
                     rawValue: groupValues.get(key),
                     count: 0
                 });
@@ -138,7 +141,7 @@ export class BoardViewDataBuilder {
             if (!hiddenSubGroups.has(key)) {
                 rows.push({
                     id: key,
-                    title: key,
+                    title: subGroupLabels[key] || key,
                     rawValue: subGroupValues.get(key),
                     count: 0
                 });

--- a/src/Views/BoardNoteCreator.ts
+++ b/src/Views/BoardNoteCreator.ts
@@ -1,8 +1,9 @@
 import Services from 'Base/Services';
-import { TFile } from 'obsidian';
-import { InternalWorkspace } from 'Types/Internal';
+import { TFile, TFolder } from 'obsidian';
+import { InternalFileManager, InternalWorkspace } from 'Types/Internal';
 import { getPropertyKeyFromId } from 'Utils';
 import { EMPTY_GROUP_VALUE } from './BoardViewRenderer';
+import { BoardOptions } from './OptionsExtractor';
 
 export class BoardNoteCreator {
     private pendingNote: {
@@ -12,16 +13,17 @@ export class BoardNoteCreator {
         subGroupPropertyId?: string | null;
     } | null = null;
 
-    handleNewNoteClick(groupValue: unknown, subGroupValue?: unknown, groupPropertyId?: string | null, subGroupPropertyId?: string | null): void {
-        // Store the pending note info
-        this.pendingNote = {
-            groupValue,
-            subGroupValue,
-            groupPropertyId,
-            subGroupPropertyId
-        };
+    handleNewNoteClick(groupValue: unknown, subGroupValue?: unknown, groupPropertyId?: string | null, subGroupPropertyId?: string | null, options?: BoardOptions): void {
+        const folder = options?.newNoteFolder || '';
+        const template = options?.newNoteTemplate || '';
 
-        // Trigger native new button
+        if (folder || template) {
+            void this.createNote(groupValue, subGroupValue, groupPropertyId, subGroupPropertyId, folder, template);
+            return;
+        }
+
+        // Default behavior: trigger native Bases new button
+        this.pendingNote = { groupValue, subGroupValue, groupPropertyId, subGroupPropertyId };
         const newButton = document.querySelector('.bases-toolbar-new-item-menu .text-icon-button');
         if (newButton instanceof HTMLElement) {
             newButton.click();
@@ -35,34 +37,65 @@ export class BoardNoteCreator {
         if (!this.pendingNote) return;
 
         try {
-            // Get the active editor's file
             const file = (Services.app.workspace as InternalWorkspace)._activeEditor?.file;
-
             if (file instanceof TFile) {
-                await this.assignGroupValues(
-                    file,
-                    this.pendingNote.groupValue,
-                    this.pendingNote.subGroupValue,
-                    this.pendingNote.groupPropertyId,
-                    this.pendingNote.subGroupPropertyId
-                );
-            } else {
-                console.warn('[BoardNoteCreator] No active editor file found');
+                await this.assignGroupValues(file, this.pendingNote.groupValue, this.pendingNote.subGroupValue, this.pendingNote.groupPropertyId, this.pendingNote.subGroupPropertyId);
             }
         } finally {
-            // Clear the pending note
             this.pendingNote = null;
         }
     }
 
+    private async createNote(groupValue: unknown, subGroupValue: unknown, groupPropertyId: string | null | undefined, subGroupPropertyId: string | null | undefined, folderPath: string, templatePath: string): Promise<void> {
+        const app = Services.app;
+        const fileManager = app.fileManager as InternalFileManager;
+        const folder = this.resolveFolder(folderPath);
+        let newFile: TFile | null = null;
+
+        try {
+            // Try Templater if template is set
+            if (templatePath) {
+                const templateFile = app.vault.getFileByPath(templatePath);
+                if (templateFile) {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const tp = (app as any).plugins?.plugins?.['templater-obsidian'];
+                    if (tp?.templater && typeof tp.templater.create_new_note_from_template === 'function') {
+                        newFile = await tp.templater.create_new_note_from_template(templateFile, folder, undefined, false) as TFile;
+                    } else {
+                        // Fallback: create file and copy template content
+                        const content = await app.vault.read(templateFile);
+                        newFile = await fileManager.createNewMarkdownFile(folder, 'Untitled');
+                        await app.vault.modify(newFile, content);
+                    }
+                }
+            }
+
+            // No template or template file not found — create blank file
+            if (!newFile) {
+                newFile = await fileManager.createNewMarkdownFile(folder, 'Untitled');
+            }
+
+            await app.workspace.openLinkText(newFile.path, '', true);
+            await this.assignGroupValues(newFile, groupValue, subGroupValue, groupPropertyId, subGroupPropertyId);
+        } catch (e) {
+            console.error('[BoardNoteCreator] Failed to create note', e);
+        }
+    }
+
+    private resolveFolder(folderPath: string): TFolder {
+        if (folderPath) {
+            const folder = Services.app.vault.getFolderByPath(folderPath);
+            if (folder) return folder;
+        }
+        return Services.app.vault.getRoot();
+    }
+
     private async assignGroupValues(file: TFile, groupValue: unknown, subGroupValue?: unknown, groupPropertyId?: string | null, subGroupPropertyId?: string | null): Promise<void> {
-        // Assign group value (skip if EMPTY_GROUP_VALUE or missing property ID)
         if (groupPropertyId && groupValue !== null && groupValue !== EMPTY_GROUP_VALUE) {
             const groupPropertyKey = getPropertyKeyFromId(groupPropertyId);
             await Services.propertyManager.updateFrontmatter(file, groupPropertyKey, groupValue);
         }
 
-        // Assign sub-group value (skip if EMPTY_GROUP_VALUE or missing property ID)
         if (subGroupPropertyId && subGroupValue !== undefined && subGroupValue !== null && subGroupValue !== EMPTY_GROUP_VALUE) {
             const subGroupPropertyKey = getPropertyKeyFromId(subGroupPropertyId);
             await Services.propertyManager.updateFrontmatter(file, subGroupPropertyKey, subGroupValue);

--- a/src/Views/BoardNoteCreator.ts
+++ b/src/Views/BoardNoteCreator.ts
@@ -18,7 +18,7 @@ export class BoardNoteCreator {
         const template = options?.newNoteTemplate || '';
 
         if (folder || template) {
-            void this.createNote(groupValue, subGroupValue, groupPropertyId, subGroupPropertyId, folder, template);
+            void this.createNote(groupValue, subGroupValue, groupPropertyId, subGroupPropertyId, folder, template, options?.newNoteOpen ?? false);
             return;
         }
 
@@ -46,7 +46,7 @@ export class BoardNoteCreator {
         }
     }
 
-    private async createNote(groupValue: unknown, subGroupValue: unknown, groupPropertyId: string | null | undefined, subGroupPropertyId: string | null | undefined, folderPath: string, templatePath: string): Promise<void> {
+    private async createNote(groupValue: unknown, subGroupValue: unknown, groupPropertyId: string | null | undefined, subGroupPropertyId: string | null | undefined, folderPath: string, templatePath: string, openAfterCreation = false): Promise<void> {
         const app = Services.app;
         const fileManager = app.fileManager as InternalFileManager;
         const folder = this.resolveFolder(folderPath);
@@ -75,7 +75,9 @@ export class BoardNoteCreator {
                 newFile = await fileManager.createNewMarkdownFile(folder, 'Untitled');
             }
 
-            await app.workspace.openLinkText(newFile.path, '', true);
+            if (openAfterCreation) {
+                await app.workspace.openLinkText(newFile.path, '', true);
+            }
             await this.assignGroupValues(newFile, groupValue, subGroupValue, groupPropertyId, subGroupPropertyId);
         } catch (e) {
             console.error('[BoardNoteCreator] Failed to create note', e);

--- a/src/Views/BoardView.ts
+++ b/src/Views/BoardView.ts
@@ -46,6 +46,8 @@ export interface BoardViewCallbacks {
     onMoveSubGroup: (subGroupValue: string, direction: 'up' | 'down') => void;
     onSetColumnColor: (groupValue: string, color: string, isSubGroup?: boolean) => void;
     onNewNoteClick: (groupValue: unknown, subGroupValue?: unknown) => void;
+    onRenameGroup: (groupValue: string, currentLabel: string) => void;
+    onRenameSubGroup: (subGroupValue: string, currentLabel: string) => void;
 }
 
 const COLUMN_COLORS = ColorManager.getColorNames().map(name =>
@@ -152,6 +154,13 @@ export class BoardView {
                         .setIcon('arrow-right')
                         .onClick(() => {
                             callbacks.onMoveGroup(column.id, 'right');
+                        });
+                });
+                menu.addItem((item) => {
+                    item.setTitle('Rename')
+                        .setIcon('pencil')
+                        .onClick(() => {
+                            callbacks.onRenameGroup(column.id, column.title);
                         });
                 });
                 menu.addItem((item) => {
@@ -266,6 +275,13 @@ export class BoardView {
                         .setIcon('arrow-down')
                         .onClick(() => {
                             callbacks.onMoveSubGroup(row.id, 'down');
+                        });
+                });
+                menu.addItem((item) => {
+                    item.setTitle('Rename')
+                        .setIcon('pencil')
+                        .onClick(() => {
+                            callbacks.onRenameSubGroup(row.id, row.title);
                         });
                 });
                 menu.addItem((item) => {

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -29,6 +29,15 @@ export class BoardViewRenderer extends BasesView {
         this.board = new BoardView(boardContainer);
         this.noteCreator = new BoardNoteCreator();
         this.hookSuperchargedLinks(boardContainer);
+
+        // Re-render when the board becomes visible (handles embed case where SL may
+        // have cleared attrs while the tab was inactive). registerEvent ensures cleanup.
+        this.registerEvent(Services.app.workspace.on('active-leaf-change', () => {
+            const activeLeafEl = Services.app.workspace.activeLeaf?.view?.containerEl;
+            if (activeLeafEl?.contains(boardContainer)) {
+                this.render();
+            }
+        }));
     }
 
     // Called by Obsidian when Bases data changes
@@ -54,6 +63,15 @@ export class BoardViewRenderer extends BasesView {
             onRenameSubGroup: (s, l) => this.openRenameModal(s, l, true),
         };
         this.board.render(boardData, callbacks);
+        this.updateSlContainer();
+    }
+
+    private updateSlContainer(): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sl = (Services.app as any).plugins?.plugins?.['supercharged-links-obsidian'];
+        if (!sl || typeof sl.updateContainer !== 'function') return;
+        // Widget renders (link pills) are async — wait for them before asking SL to process
+        setTimeout(() => sl.updateContainer(this.containerEl, sl, '[data-href]'), 100);
     }
 
     private extractOptions(): BoardOptions {

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -9,14 +9,18 @@ import { BoardOptionKeys, BoardOptions, OptionsExtractor } from './OptionsExtrac
 
 export const EMPTY_GROUP_VALUE = 'Empty Group';
 
+let instanceCounter = 0;
+
 export class BoardViewRenderer extends BasesView {
     readonly type = BASES_VIEW_ID;
+    private readonly slWatchId: string;
     private containerEl: HTMLElement;
     public controller: QueryController;
     private board: BoardView;
     private noteCreator: BoardNoteCreator;
     constructor(controller: QueryController, parentEl: HTMLElement) {
         super(controller);
+        this.slWatchId = `board-view-${++instanceCounter}`;
         this.controller = controller;
         this.containerEl = parentEl.createDiv('board-view');
         const boardContainer = this.containerEl.createDiv('board-board-container');
@@ -24,6 +28,7 @@ export class BoardViewRenderer extends BasesView {
         // Initialize BoardView
         this.board = new BoardView(boardContainer);
         this.noteCreator = new BoardNoteCreator();
+        this.hookSuperchargedLinks(boardContainer);
     }
 
     // Called by Obsidian when Bases data changes
@@ -168,6 +173,19 @@ export class BoardViewRenderer extends BasesView {
             this.config.set(key, filtered);
         });
         modal.open();
+    }
+
+    private hookSuperchargedLinks(container: HTMLElement): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sl = (Services.app as any).plugins?.plugins?.['supercharged-links-obsidian'];
+        if (!sl || typeof sl._watchContainerDynamic !== 'function') return;
+        sl._watchContainerDynamic(
+            this.slWatchId,
+            container,
+            sl,
+            '.internal-link',
+            'board-card',
+        );
     }
 
     private handleNewNoteClick(groupValue: unknown, subGroupValue?: unknown): void {

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -1,7 +1,7 @@
 import Services from 'Base/Services';
 import { getPropertyKeyFromId } from 'Utils';
 import { BASES_VIEW_ID } from 'main';
-import { BasesView, Notice, QueryController } from 'obsidian';
+import { BasesView, Modal, Notice, QueryController } from 'obsidian';
 import { BoardViewDataBuilder } from './BoardDataBuilder';
 import { BoardNoteCreator } from './BoardNoteCreator';
 import { BoardView, BoardViewCallbacks, BoardViewData } from './BoardView';
@@ -45,6 +45,8 @@ export class BoardViewRenderer extends BasesView {
             onMoveSubGroup: (s, d) => this.moveSubGroup(s, d),
             onSetColumnColor: (g, c, s) => { void this.setColumnColor(g, c, s); },
             onNewNoteClick: (g, s) => this.handleNewNoteClick(g, s),
+            onRenameGroup: (g, l) => this.openRenameModal(g, l, false),
+            onRenameSubGroup: (s, l) => this.openRenameModal(s, l, true),
         };
         this.board.render(boardData, callbacks);
     }
@@ -154,6 +156,20 @@ export class BoardViewRenderer extends BasesView {
         this.render();
     }
 
+    private openRenameModal(value: string, currentLabel: string, isSubGroup: boolean) {
+        const modal = new RenameModal(Services.app, currentLabel, (newLabel) => {
+            const key = isSubGroup ? BoardOptionKeys.SUB_GROUP_LABELS : BoardOptionKeys.GROUP_LABELS;
+            const current = (this.config.get(key) as string[]) || [];
+            const prefix = `${value}=`;
+            const filtered = current.filter(e => !e.startsWith(prefix));
+            if (newLabel.trim()) {
+                filtered.push(`${value}=${newLabel.trim()}`);
+            }
+            this.config.set(key, filtered);
+        });
+        modal.open();
+    }
+
     private handleNewNoteClick(groupValue: unknown, subGroupValue?: unknown): void {
         const options = this.extractOptions();
         this.noteCreator.handleNewNoteClick(
@@ -164,4 +180,47 @@ export class BoardViewRenderer extends BasesView {
         );
     }
 
+}
+
+class RenameModal extends Modal {
+    private currentLabel: string;
+    private onSubmit: (newLabel: string) => void;
+
+    constructor(app: import('obsidian').App, currentLabel: string, onSubmit: (newLabel: string) => void) {
+        super(app);
+        this.currentLabel = currentLabel;
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen() {
+        const { contentEl, modalEl } = this;
+        modalEl.style.width = '320px';
+        modalEl.style.minWidth = 'unset';
+        contentEl.style.padding = '16px';
+
+        const input = contentEl.createEl('input', { type: 'text' });
+        input.value = this.currentLabel;
+        input.placeholder = 'Display name';
+        input.style.width = '100%';
+        input.style.marginBottom = '12px';
+
+        const submit = () => {
+            this.onSubmit(input.value);
+            this.close();
+        };
+
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') submit();
+            if (e.key === 'Escape') this.close();
+        });
+
+        const btn = contentEl.createEl('button', { text: 'Rename' });
+        btn.addEventListener('click', submit);
+
+        setTimeout(() => { input.focus(); input.select(); }, 50);
+    }
+
+    onClose() {
+        this.contentEl.empty();
+    }
 }

--- a/src/Views/BoardViewRenderer.ts
+++ b/src/Views/BoardViewRenderer.ts
@@ -194,7 +194,8 @@ export class BoardViewRenderer extends BasesView {
             groupValue,
             subGroupValue,
             options.groupProperty,
-            options.subGroupProperty
+            options.subGroupProperty,
+            options
         );
     }
 

--- a/src/Views/CardView.ts
+++ b/src/Views/CardView.ts
@@ -1,6 +1,7 @@
-import { BasesEntry, Menu, WorkspaceLeaf } from 'obsidian';
+import { BasesEntry, Menu, Modal, WorkspaceLeaf } from 'obsidian';
 import { InternalWorkspace } from 'Types/Internal';
 import Services from '../Base/Services';
+import { getPropertyKeyFromId } from 'Utils';
 import { ColorManager } from './ColorManager';
 import { BoardOptions } from './OptionsExtractor';
 import { PropertyView } from './PropertyView';
@@ -115,17 +116,38 @@ export class CardView {
 
         // ID badge above title
         if (this.options.idProperty) {
-            const idValue = entry.getValue(this.options.idProperty);
+            const idPropertyId = this.options.idProperty;
+            const idValue = entry.getValue(idPropertyId);
             if (idValue?.isTruthy()) {
                 const idText = idValue.toString();
                 const idEl = document.createElement('div');
                 idEl.classList.add('card-id');
                 idEl.textContent = idText;
+
+                // Stop mouseup so card doesn't open
+                idEl.addEventListener('mouseup', (evt) => {
+                    evt.stopPropagation();
+                });
+
+                // Left click — copy to clipboard
                 idEl.addEventListener('click', (evt) => {
                     evt.preventDefault();
                     evt.stopPropagation();
                     navigator.clipboard.writeText(idText);
                 });
+
+                // Right click — edit value
+                idEl.addEventListener('contextmenu', (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    const modal = new IdEditModal(Services.app, idText, async (newValue) => {
+                        const key = getPropertyKeyFromId(idPropertyId);
+                        const file = Services.propertyManager.getFile(entry.file.path);
+                        if (file) await Services.propertyManager.updateFrontmatter(file, key, newValue);
+                    });
+                    modal.open();
+                });
+
                 card.appendChild(idEl);
             }
         }
@@ -143,5 +165,45 @@ export class CardView {
         }
 
         return card;
+    }
+}
+
+class IdEditModal extends Modal {
+    constructor(
+        app: import('obsidian').App,
+        private currentValue: string,
+        private onSubmit: (newValue: string) => Promise<void>
+    ) {
+        super(app);
+    }
+
+    onOpen() {
+        const { contentEl, modalEl } = this;
+        modalEl.style.width = '280px';
+        modalEl.style.minWidth = 'unset';
+        contentEl.style.padding = '16px';
+
+        const input = contentEl.createEl('input', { type: 'text' });
+        input.value = this.currentValue;
+        input.style.width = '100%';
+        input.style.marginBottom = '12px';
+
+        const submit = () => {
+            void this.onSubmit(input.value.trim()).then(() => this.close());
+        };
+
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') submit();
+            if (e.key === 'Escape') this.close();
+        });
+
+        const btn = contentEl.createEl('button', { text: 'Save' });
+        btn.addEventListener('click', submit);
+
+        setTimeout(() => { input.focus(); input.select(); }, 50);
+    }
+
+    onClose() {
+        this.contentEl.empty();
     }
 }

--- a/src/Views/CardView.ts
+++ b/src/Views/CardView.ts
@@ -113,6 +113,23 @@ export class CardView {
             }
         }
 
+        // ID badge above title
+        if (this.options.idProperty) {
+            const idValue = entry.getValue(this.options.idProperty);
+            if (idValue?.isTruthy()) {
+                const idText = idValue.toString();
+                const idEl = document.createElement('div');
+                idEl.classList.add('card-id');
+                idEl.textContent = idText;
+                idEl.addEventListener('click', (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    navigator.clipboard.writeText(idText);
+                });
+                card.appendChild(idEl);
+            }
+        }
+
         // create PropertyView helper
         const propertyView = new PropertyView({
             options: this.options

--- a/src/Views/CardView.ts
+++ b/src/Views/CardView.ts
@@ -1,4 +1,4 @@
-import { BasesEntry, Menu, Modal, WorkspaceLeaf } from 'obsidian';
+import { BasesEntry, Menu, Modal, Notice, WorkspaceLeaf } from 'obsidian';
 import { InternalWorkspace } from 'Types/Internal';
 import Services from '../Base/Services';
 import { getPropertyKeyFromId } from 'Utils';
@@ -134,6 +134,7 @@ export class CardView {
                     evt.preventDefault();
                     evt.stopPropagation();
                     navigator.clipboard.writeText(idText);
+                    new Notice(`Copied: ${idText}`, 1500);
                 });
 
                 // Right click — edit value

--- a/src/Views/IconPickerModal.ts
+++ b/src/Views/IconPickerModal.ts
@@ -1,0 +1,63 @@
+import { App, Modal, Notice, getIconIds, setIcon } from 'obsidian';
+
+const ICONS_PER_PAGE = 300;
+
+export class IconPickerModal extends Modal {
+    constructor(app: App) {
+        super(app);
+    }
+
+    onOpen() {
+        const { contentEl, modalEl } = this;
+        modalEl.style.width = '640px';
+        modalEl.style.maxWidth = '90vw';
+        contentEl.empty();
+        contentEl.style.padding = '16px';
+
+        const allIcons = getIconIds().sort();
+
+        const searchEl = contentEl.createEl('input', { type: 'text', placeholder: 'Search icons…' });
+        searchEl.style.cssText = 'width:100%;margin-bottom:12px;box-sizing:border-box;';
+
+        const hint = contentEl.createEl('p');
+        hint.style.cssText = 'margin:0 0 10px;font-size:var(--font-ui-smaller);color:var(--text-muted);';
+        hint.textContent = `${allIcons.length} icons — click to copy name`;
+
+        const gridEl = contentEl.createDiv('icon-picker-grid');
+
+        const render = (icons: string[]) => {
+            gridEl.empty();
+            const slice = icons.slice(0, ICONS_PER_PAGE);
+            for (const id of slice) {
+                const item = gridEl.createDiv('icon-picker-item');
+                const iconWrap = item.createDiv('icon-picker-icon');
+                setIcon(iconWrap, id);
+                item.createDiv({ cls: 'icon-picker-name', text: id });
+                item.addEventListener('click', () => {
+                    navigator.clipboard.writeText(id);
+                    new Notice(`Copied: ${id}`, 1500);
+                });
+            }
+            if (icons.length > ICONS_PER_PAGE) {
+                const more = gridEl.createEl('p');
+                more.style.cssText = 'width:100%;text-align:center;color:var(--text-muted);font-size:var(--font-ui-smaller);margin-top:8px;';
+                more.textContent = `Showing ${ICONS_PER_PAGE} of ${icons.length} — refine your search`;
+            }
+        };
+
+        render(allIcons);
+
+        searchEl.addEventListener('input', () => {
+            const q = searchEl.value.toLowerCase().trim();
+            const filtered = q ? allIcons.filter(id => id.includes(q)) : allIcons;
+            hint.textContent = `${filtered.length} icons — click to copy name`;
+            render(filtered);
+        });
+
+        setTimeout(() => { searchEl.focus(); }, 50);
+    }
+
+    onClose() {
+        this.contentEl.empty();
+    }
+}

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -20,6 +20,7 @@ export const BoardOptionKeys = {
     HIDE_IMAGE_PLACEHOLDER: 'hideImagePlaceholder',
     NEW_NOTE_FOLDER: 'newNoteFolder',
     NEW_NOTE_TEMPLATE: 'newNoteTemplate',
+    NEW_NOTE_OPEN: 'newNoteOpen',
 
     // Color Options (simplified)
     COLOR_HEADERS: 'colorHeaders',
@@ -45,6 +46,7 @@ export interface BoardOptions {
     hideImagePlaceholder?: boolean;
     newNoteFolder?: string;
     newNoteTemplate?: string;
+    newNoteOpen?: boolean;
 
     // Color Options
     colorHeaders?: boolean;
@@ -108,6 +110,7 @@ export class OptionsExtractor {
         options.hideImagePlaceholder = (this.config.get(BoardOptionKeys.HIDE_IMAGE_PLACEHOLDER) as boolean) || false;
         options.newNoteFolder = ((this.config.get(BoardOptionKeys.NEW_NOTE_FOLDER) as string[]) || [])[0] || '';
         options.newNoteTemplate = ((this.config.get(BoardOptionKeys.NEW_NOTE_TEMPLATE) as string[]) || [])[0] || '';
+        options.newNoteOpen = (this.config.get(BoardOptionKeys.NEW_NOTE_OPEN) as boolean) || false;
 
         // Color Options
         options.colorHeaders = (this.config.get(BoardOptionKeys.COLOR_HEADERS) as boolean) || true;

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -23,6 +23,9 @@ export const BoardOptionKeys = {
     NEW_NOTE_TEMPLATE: 'newNoteTemplate',
     NEW_NOTE_OPEN: 'newNoteOpen',
 
+    // Icon mapping
+    ICON_MAPPING: 'iconMapping',
+
     // Color Options (simplified)
     COLOR_HEADERS: 'colorHeaders',
     COLOR_CELLS: 'colorCells',
@@ -49,6 +52,9 @@ export interface BoardOptions {
     newNoteFolder?: string;
     newNoteTemplate?: string;
     newNoteOpen?: boolean;
+
+    // Icon mapping: property value → lucide icon name
+    iconMapping?: Record<string, string>;
 
     // Color Options
     colorHeaders?: boolean;
@@ -114,6 +120,8 @@ export class OptionsExtractor {
         options.newNoteFolder = ((this.config.get(BoardOptionKeys.NEW_NOTE_FOLDER) as string[]) || [])[0] || '';
         options.newNoteTemplate = ((this.config.get(BoardOptionKeys.NEW_NOTE_TEMPLATE) as string[]) || [])[0] || '';
         options.newNoteOpen = (this.config.get(BoardOptionKeys.NEW_NOTE_OPEN) as boolean) || false;
+
+        options.iconMapping = parseLabels((this.config.get(BoardOptionKeys.ICON_MAPPING) as string[]) || []);
 
         // Color Options
         options.colorHeaders = (this.config.get(BoardOptionKeys.COLOR_HEADERS) as boolean) || true;

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -18,6 +18,8 @@ export const BoardOptionKeys = {
     HIDDEN_GROUPS: 'hiddenGroups',
     HIDDEN_SUB_GROUPS: 'hiddenSubGroups',
     HIDE_IMAGE_PLACEHOLDER: 'hideImagePlaceholder',
+    NEW_NOTE_FOLDER: 'newNoteFolder',
+    NEW_NOTE_TEMPLATE: 'newNoteTemplate',
 
     // Color Options (simplified)
     COLOR_HEADERS: 'colorHeaders',
@@ -41,6 +43,8 @@ export interface BoardOptions {
     hiddenGroups?: string[];
     hiddenSubGroups?: string[];
     hideImagePlaceholder?: boolean;
+    newNoteFolder?: string;
+    newNoteTemplate?: string;
 
     // Color Options
     colorHeaders?: boolean;
@@ -102,6 +106,8 @@ export class OptionsExtractor {
         options.hiddenGroups = (this.config.get(BoardOptionKeys.HIDDEN_GROUPS) as string[]) || [];
         options.hiddenSubGroups = (this.config.get(BoardOptionKeys.HIDDEN_SUB_GROUPS) as string[]) || [];
         options.hideImagePlaceholder = (this.config.get(BoardOptionKeys.HIDE_IMAGE_PLACEHOLDER) as boolean) || false;
+        options.newNoteFolder = ((this.config.get(BoardOptionKeys.NEW_NOTE_FOLDER) as string[]) || [])[0] || '';
+        options.newNoteTemplate = ((this.config.get(BoardOptionKeys.NEW_NOTE_TEMPLATE) as string[]) || [])[0] || '';
 
         // Color Options
         options.colorHeaders = (this.config.get(BoardOptionKeys.COLOR_HEADERS) as boolean) || true;

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -9,6 +9,8 @@ export const BoardOptionKeys = {
     ICON_PROPERTY: 'iconProperty',
     GROUP_ORDER: 'groupOrder',
     SUB_GROUP_ORDER: 'subGroupOrder',
+    GROUP_LABELS: 'groupLabels',
+    SUB_GROUP_LABELS: 'subGroupLabels',
     HIDE_EMPTY_GROUPS: 'hideEmptyGroups',
     HIDE_EMPTY_SUB_GROUPS: 'hideEmptySubGroups',
     CARD_SIZE: 'cardSize',
@@ -30,6 +32,8 @@ export interface BoardOptions {
     iconProperty?: BasesPropertyId | null;
     groupOrder?: string[];
     subGroupOrder?: string[];
+    groupLabels?: Record<string, string>;
+    subGroupLabels?: Record<string, string>;
     hideEmptyGroups?: boolean;
     hideEmptySubGroups?: boolean;
     cardSize?: 'small' | 'medium' | 'large';
@@ -42,6 +46,17 @@ export interface BoardOptions {
     colorHeaders?: boolean;
     colorCells?: boolean;
     colorCards?: boolean; // minimal mode only (left border)
+}
+
+function parseLabels(entries: string[]): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const entry of entries) {
+        const sep = entry.indexOf('=');
+        if (sep > 0) {
+            result[entry.slice(0, sep).trim()] = entry.slice(sep + 1).trim();
+        }
+    }
+    return result;
 }
 
 export class OptionsExtractor {
@@ -78,6 +93,8 @@ export class OptionsExtractor {
         options.iconProperty = (this.config.get(BoardOptionKeys.ICON_PROPERTY) as BasesPropertyId | null) || null;
         options.groupOrder = (this.config.get(BoardOptionKeys.GROUP_ORDER) as string[]) || [];
         options.subGroupOrder = (this.config.get(BoardOptionKeys.SUB_GROUP_ORDER) as string[]) || [];
+        options.groupLabels = parseLabels((this.config.get(BoardOptionKeys.GROUP_LABELS) as string[]) || []);
+        options.subGroupLabels = parseLabels((this.config.get(BoardOptionKeys.SUB_GROUP_LABELS) as string[]) || []);
         options.hideEmptyGroups = (this.config.get(BoardOptionKeys.HIDE_EMPTY_GROUPS) as boolean) || false;
         options.hideEmptySubGroups = (this.config.get(BoardOptionKeys.HIDE_EMPTY_SUB_GROUPS) as boolean) || false;
         options.cardSize = (this.config.get(BoardOptionKeys.CARD_SIZE) as 'small' | 'medium' | 'large') || 'medium';

--- a/src/Views/OptionsExtractor.ts
+++ b/src/Views/OptionsExtractor.ts
@@ -7,6 +7,7 @@ export const BoardOptionKeys = {
     SUB_GROUP_PROPERTY: 'subGroupProperty',
     IMAGE_PROPERTY: 'imageProperty',
     ICON_PROPERTY: 'iconProperty',
+    ID_PROPERTY: 'idProperty',
     GROUP_ORDER: 'groupOrder',
     SUB_GROUP_ORDER: 'subGroupOrder',
     GROUP_LABELS: 'groupLabels',
@@ -33,6 +34,7 @@ export interface BoardOptions {
     subGroupProperty?: BasesPropertyId | null;
     imageProperty?: BasesPropertyId | null;
     iconProperty?: BasesPropertyId | null;
+    idProperty?: BasesPropertyId | null;
     groupOrder?: string[];
     subGroupOrder?: string[];
     groupLabels?: Record<string, string>;
@@ -97,6 +99,7 @@ export class OptionsExtractor {
         options.subGroupProperty = subGroupProperty;
         options.imageProperty = (this.config.get(BoardOptionKeys.IMAGE_PROPERTY) as BasesPropertyId | null) || null;
         options.iconProperty = (this.config.get(BoardOptionKeys.ICON_PROPERTY) as BasesPropertyId | null) || null;
+        options.idProperty = (this.config.get(BoardOptionKeys.ID_PROPERTY) as BasesPropertyId | null) || null;
         options.groupOrder = (this.config.get(BoardOptionKeys.GROUP_ORDER) as string[]) || [];
         options.subGroupOrder = (this.config.get(BoardOptionKeys.SUB_GROUP_ORDER) as string[]) || [];
         options.groupLabels = parseLabels((this.config.get(BoardOptionKeys.GROUP_LABELS) as string[]) || []);

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -4,6 +4,12 @@ import { BasesEntry, BasesPropertyId, RenderContext, setIcon } from 'obsidian';
 import Services from '../Base/Services';
 import { BoardOptions } from './OptionsExtractor';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getSl(): any {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (Services.app as any).plugins?.plugins?.['supercharged-links-obsidian'] ?? null;
+}
+
 export interface PropertyViewContext {
     options?: BoardOptions;
 }
@@ -97,34 +103,17 @@ export class PropertyView {
                 (widget as { render: (el: HTMLElement, value: unknown, context: unknown) => void; }).render(child, propertyValue, context);
             }
 
-            // Supercharged Links: apply data-link-* from target file's frontmatter.
-            // Widget renders async, so we defer the scan to let the DOM settle.
-            const sourcePath = entry.file.path;
-            requestAnimationFrame(() => {
-                for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
-                    const href = link.getAttribute('data-href') || '';
-                    if (!href) continue;
-                    applySlAttributes(link, href, sourcePath);
-                }
-            });
+            // Let Supercharged Links process any link pills the widget rendered.
+            // Widget renders are async (rAF/timeout), so we give a short delay then
+            // call SL's own updateContainer() — it applies data-link-* attrs exactly
+            // as it would for any other Obsidian view.
+            const sl = getSl();
+            if (sl && typeof sl.updateContainer === 'function') {
+                setTimeout(() => sl.updateContainer(child, sl, '[data-href]'), 50);
+            }
         }
 
         return propEl;
     }
 }
 
-function applySlAttributes(link: HTMLElement, href: string, sourcePath: string): void {
-    const target = Services.app.metadataCache.getFirstLinkpathDest(href, sourcePath);
-    if (!target) return;
-    const fm = Services.app.metadataCache.getCache(target.path)?.frontmatter;
-    if (!fm) return;
-    link.classList.add('data-link-icon', 'data-link-icon-after', 'data-link-text');
-    for (const [key, val] of Object.entries(fm)) {
-        if (key === 'position') continue;
-        if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
-            const strVal = String(val);
-            link.setAttribute(`data-link-${key}`, strVal);
-            link.style.setProperty(`--data-link-${key}`, strVal);
-        }
-    }
-}

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -98,13 +98,15 @@ export class PropertyView {
             }
 
             // Supercharged Links: apply data-link-* from target file's frontmatter.
-            // Obsidian's link widget renders pills as div.internal-link[data-href],
-            // so we use a broad attribute selector instead of restricting to <a>.
-            for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
-                const href = link.getAttribute('data-href') || '';
-                if (!href) continue;
-                applySlAttributes(link, href, entry.file.path);
-            }
+            // Widget renders async, so we defer the scan to let the DOM settle.
+            const sourcePath = entry.file.path;
+            requestAnimationFrame(() => {
+                for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
+                    const href = link.getAttribute('data-href') || '';
+                    if (!href) continue;
+                    applySlAttributes(link, href, sourcePath);
+                }
+            });
         }
 
         return propEl;

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -96,8 +96,33 @@ export class PropertyView {
                 const widget = (Services.app as InternalApp).metadataTypeManager.registeredTypeWidgets[propertyNativeType];
                 (widget as { render: (el: HTMLElement, value: unknown, context: unknown) => void; }).render(child, propertyValue, context);
             }
+
+            // Supercharged Links: apply data-link-* from target file's frontmatter.
+            // Obsidian's link widget renders pills as div.internal-link[data-href],
+            // so we use a broad attribute selector instead of restricting to <a>.
+            for (const link of Array.from(child.querySelectorAll<HTMLElement>('[data-href]'))) {
+                const href = link.getAttribute('data-href') || '';
+                if (!href) continue;
+                applySlAttributes(link, href, entry.file.path);
+            }
         }
 
         return propEl;
+    }
+}
+
+function applySlAttributes(link: HTMLElement, href: string, sourcePath: string): void {
+    const target = Services.app.metadataCache.getFirstLinkpathDest(href, sourcePath);
+    if (!target) return;
+    const fm = Services.app.metadataCache.getCache(target.path)?.frontmatter;
+    if (!fm) return;
+    link.classList.add('data-link-icon', 'data-link-icon-after', 'data-link-text');
+    for (const [key, val] of Object.entries(fm)) {
+        if (key === 'position') continue;
+        if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
+            const strVal = String(val);
+            link.setAttribute(`data-link-${key}`, strVal);
+            link.style.setProperty(`--data-link-${key}`, strVal);
+        }
     }
 }

--- a/src/Views/PropertyView.ts
+++ b/src/Views/PropertyView.ts
@@ -41,10 +41,14 @@ export class PropertyView {
                 // Create container for icon + file name
                 propEl.classList.add('board-card-file-name-container');
 
+                // Resolve icon name through mapping (fallback to raw value)
+                const rawIconValue = iconVal.toString();
+                const iconName = this.options?.iconMapping?.[rawIconValue] ?? rawIconValue;
+
                 // Create icon element
                 const iconEl = document.createElement('span');
                 iconEl.classList.add('board-card-icon');
-                setIcon(iconEl, iconVal.toString());
+                setIcon(iconEl, iconName);
 
                 // Create file name element
                 const fileNameEl = document.createElement('div');

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,6 +193,26 @@ export default class BoardViewPlugin extends Plugin {
 						}
 					]
 				},
+				{
+					type: 'group',
+					displayName: 'New Note',
+					items: [
+						{
+							type: 'multitext',
+							displayName: 'Folder',
+							key: BoardOptionKeys.NEW_NOTE_FOLDER,
+							default: [],
+							description: 'Folder path for new notes (e.g. Projects/Tasks)',
+						},
+						{
+							type: 'multitext',
+							displayName: 'Template',
+							key: BoardOptionKeys.NEW_NOTE_TEMPLATE,
+							default: [],
+							description: 'Template file path. Supports Templater if installed (e.g. Templates/Task.md)',
+						},
+					]
+				},
 			]),
 		});
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,13 @@ export default class BoardViewPlugin extends Plugin {
 							default: [],
 							description: 'Order of main group (columns)',
 						},
+						{
+							type: 'multitext',
+							displayName: 'Group labels',
+							key: BoardOptionKeys.GROUP_LABELS,
+							default: [],
+							description: 'Custom display names for groups, format: value=Label',
+						},
 					]
 				},
 				{
@@ -155,6 +162,13 @@ export default class BoardViewPlugin extends Plugin {
 							key: BoardOptionKeys.SUB_GROUP_ORDER,
 							default: [],
 							description: 'Order of sub group (rows)',
+						},
+						{
+							type: 'multitext',
+							displayName: 'Sub Group labels',
+							key: BoardOptionKeys.SUB_GROUP_LABELS,
+							default: [],
+							description: 'Custom display names for sub-groups, format: value=Label',
 						},
 					]
 				},

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,6 +211,13 @@ export default class BoardViewPlugin extends Plugin {
 							default: [],
 							description: 'Template file path. Supports Templater if installed (e.g. Templates/Task.md)',
 						},
+						{
+							type: 'toggle',
+							displayName: 'Open after creation',
+							key: BoardOptionKeys.NEW_NOTE_OPEN,
+							default: false,
+							description: 'Open the new note after creating it',
+						},
 					]
 				},
 			]),

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,7 @@ export default class BoardViewPlugin extends Plugin {
 							displayName: 'Hide empty groups',
 							key: BoardOptionKeys.HIDE_EMPTY_GROUPS,
 							default: false,
-							description: 'Hide empty groups (columns)',
+							description: 'Hide groups with no cards. When off, groups from Group order are always shown',
 						},
 						{
 							type: 'multitext',

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { BoardViewSettingTab, BoardViewSettings, DEFAULT_SETTINGS } from 'Base/S
 import { Plugin, QueryController } from 'obsidian';
 import { getPropertyKeyFromId } from 'Utils';
 import { BoardViewRenderer } from 'Views/BoardViewRenderer';
+import { IconPickerModal } from 'Views/IconPickerModal';
 import { BoardOptionKeys } from 'Views/OptionsExtractor';
 import Services from './Base/Services';
 
@@ -21,6 +22,13 @@ export default class BoardViewPlugin extends Plugin {
 
 		// Initialize plugin UI (ribbon icons, commands)
 		PluginInterface.initialize();
+
+		// Icon picker command
+		this.addCommand({
+			id: 'browse-icons',
+			name: 'Browse icons',
+			callback: () => new IconPickerModal(this.app).open(),
+		});
 
 		// Add settings tab
 		this.addSettingTab(new BoardViewSettingTab(this.app, this));
@@ -51,6 +59,13 @@ export default class BoardViewPlugin extends Plugin {
 							filter: (prop: string) => Services.plugin.isPropertyEligibleForGrouping(prop),
 							default: '',
 							description: 'Enter the property ID to display as card icon',
+						},
+						{
+							type: 'multitext',
+							displayName: 'Icon mapping',
+							key: BoardOptionKeys.ICON_MAPPING,
+							default: [],
+							description: 'Map property values to icon names. Format: value=icon-name (e.g. bug=bug, feature=sparkles). Use "Board View: Browse icons" command to search icons.',
 						},
 						{
 							type: 'property',

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,14 @@ export default class BoardViewPlugin extends Plugin {
 							description: 'Enter the property ID to display as card icon',
 						},
 						{
+							type: 'property',
+							displayName: 'ID Property',
+							key: BoardOptionKeys.ID_PROPERTY,
+							filter: (prop: string) => Services.plugin.isPropertyEligibleForGrouping(prop),
+							default: '',
+							description: 'Property to show as a muted ID above the card title. Click copies it to clipboard.',
+						},
+						{
 							type: 'toggle',
 							displayName: 'Open in side view',
 							key: BoardOptionKeys.OPEN_IN_SIDE_VIEW,

--- a/styles.css
+++ b/styles.css
@@ -454,3 +454,11 @@ body {
     text-decoration: none;
     padding-left: 6px;
 }
+
+.card-id {
+    padding-left: 6px;
+    font-size: var(--font-ui-smaller);
+    opacity: 0.45;
+    cursor: pointer;
+    user-select: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -462,3 +462,42 @@ body {
     cursor: pointer;
     user-select: none;
 }
+
+/* Icon Picker Modal */
+.icon-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(76px, 1fr));
+    gap: 4px;
+    max-height: 420px;
+    overflow-y: auto;
+}
+
+.icon-picker-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px 4px;
+    border-radius: 6px;
+    cursor: pointer;
+    text-align: center;
+}
+
+.icon-picker-item:hover {
+    background: var(--background-modifier-hover);
+}
+
+.icon-picker-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin-bottom: 4px;
+}
+
+.icon-picker-name {
+    font-size: 10px;
+    color: var(--text-muted);
+    word-break: break-all;
+    line-height: 1.2;
+}


### PR DESCRIPTION
- Add \`iconMapping\` option (multitext, \`value=icon-name\` format) to map property values to Lucide icon names independently from the stored value (e.g. \`bug=bug\`, \`feature=sparkles\`, \`improvement=trending-up\`)
- Falls back to raw value if no mapping is set, so existing setups are unaffected
- Add \`IconPickerModal\`: searchable grid of all registered Lucide icons, click to copy name — opened via "Board View: Browse icons" command